### PR TITLE
Add dRPC to Gnosis RPC Providers

### DIFF
--- a/docs/tools/RPC Providers/README.md
+++ b/docs/tools/RPC Providers/README.md
@@ -114,6 +114,15 @@ high throughput for your production grade projects.
 
 Free API keys after signing up.
 
+## dRPC
+
+dRPC NodeCloud offers an AI-powered load-balancer, 180+ network endpoints, flat-rate pricing 
+(20 CUs/method), usage analytics, and team features. PAYG from $10 — full speed, no limits.
+
+- [Gnosis endpoints](https://drpc.org/chainlist/gnosis-mainnet-rpc)
+- [Docs](https://drpc.org/docs)
+- [Chainlist](https://drpc.org/chainlist)
+
 ## Quicknode
 
 - [Quicknode's Docs for Gnosis RPCs](https://www.quicknode.com/docs/gnosis)


### PR DESCRIPTION
This PR adds dRPC as a new RPC provider under Gnosis’ “RPC Providers” list.

- Load-balanced, multichain RPC platform  
- Access to 180+ networks  
- Flat-rate per-method pricing (20 CUs)  
- No key or rate limits  
- PAYG & team management features  
- Usage analytics dashboard  
- From $10 — full speed, no limits

Website: https://drpc.org  
Docs: https://drpc.org/docs